### PR TITLE
Bugfix #11: Remote urls not working correctly.

### DIFF
--- a/WebViewScreenSaver/WVSSAddressListFetcher.h
+++ b/WebViewScreenSaver/WVSSAddressListFetcher.h
@@ -20,6 +20,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "WVSSAddress.h"
 
 @protocol WVSSAddressListFetcherDelegate;
 

--- a/WebViewScreenSaver/WVSSAddressListFetcher.m
+++ b/WebViewScreenSaver/WVSSAddressListFetcher.m
@@ -20,6 +20,7 @@
 //
 
 #import "WVSSAddressListFetcher.h"
+#import "WVSSAddress.h"
 
 @interface WVSSAddressListFetcher ()
 @property (nonatomic, strong) NSMutableData *receivedData;
@@ -73,7 +74,11 @@
     return;
   }
 
-  [self.delegate addressListFetcher:self didFinishWithArray:response];
+    NSMutableArray<WVSSAddress*> *responseAddresses = [NSMutableArray array];
+    for(NSString *addressResponse in (NSArray*)response) {
+        [responseAddresses addObject:[WVSSAddress addressWithURL:addressResponse duration:300]];
+    }
+  [self.delegate addressListFetcher:self didFinishWithArray:responseAddresses];
   self.connection = nil;
   NSLog(@"fetching URLS finished");
 }

--- a/WebViewScreenSaver/WVSSConfig.h
+++ b/WebViewScreenSaver/WVSSConfig.h
@@ -25,7 +25,7 @@
 
 @interface WVSSConfig : NSObject
 
-@property(nonatomic, strong, readonly) NSMutableArray *addresses;
+@property(nonatomic, strong, readonly) NSMutableArray<WVSSAddress*> *addresses;
 @property(nonatomic, strong) NSString *addressListURL;
 @property(nonatomic, assign) BOOL shouldFetchAddressList;
 

--- a/WebViewScreenSaver/WVSSConfig.m
+++ b/WebViewScreenSaver/WVSSConfig.m
@@ -30,7 +30,7 @@ static NSString * const kScreenSaverURLListKey = @"kScreenSaverURLList";  // NSA
 
 @interface WVSSConfig ()
 @property(nonatomic, strong) NSUserDefaults *userDefaults;
-@property(nonatomic, strong) NSMutableArray *addresses;
+@property(nonatomic, strong) NSMutableArray<WVSSAddress*> *addresses;
 @end
 
 @implementation WVSSConfig
@@ -53,9 +53,9 @@ static NSString * const kScreenSaverURLListKey = @"kScreenSaverURLList";  // NSA
   return self;
 }
 
-- (NSMutableArray *)loadAddressesFromUserDefaults:(NSUserDefaults *)userDefaults {
+- (NSMutableArray<WVSSAddress*> *)loadAddressesFromUserDefaults:(NSUserDefaults *)userDefaults {
   NSArray *addressesFromUserDefaults = [[userDefaults arrayForKey:kScreenSaverURLListKey] mutableCopy];
-  NSMutableArray *addresses = [NSMutableArray array];
+  NSMutableArray<WVSSAddress*> *addresses = [NSMutableArray array];
   for (NSDictionary *addressDictionary in addressesFromUserDefaults) {
 
     NSString *url = addressDictionary[kWVSSAddressURLKey];
@@ -81,11 +81,11 @@ static NSString * const kScreenSaverURLListKey = @"kScreenSaverURLList";  // NSA
 - (void)synchronize {
   [self saveAddressesToUserDefaults:self.userDefaults];
   [self.userDefaults setBool:self.shouldFetchAddressList forKey:kScreenSaverFetchURLsKey];
-
+    
   if (self.addressListURL.length) {
     [self.userDefaults setObject:self.addressListURL forKey:kScreenSaverURLsURLKey];
   } else {
-    [self.userDefaults removeObjectForKey:kScreenSaverURLsURLKey];
+      [self.userDefaults removeObjectForKey:kScreenSaverURLsURLKey];
   }
   [self.userDefaults synchronize];
 

--- a/WebViewScreenSaver/WVSSConfigController.m
+++ b/WebViewScreenSaver/WVSSConfigController.m
@@ -114,7 +114,7 @@ NS_ENUM(NSInteger, WVSSColumn) {
 }
 
 - (void)addressListFetcher:(WVSSAddressListFetcher *)fetcher
-        didFinishWithArray:(NSArray *)response {
+        didFinishWithArray:(NSArray<WVSSAddress*> *)response {
   [self.config.addresses removeAllObjects];
   [self.config.addresses addObjectsFromArray:response];
   [self.urlTable reloadData];


### PR DESCRIPTION
It looks like NSMutableArray's typing was unclear and two things were
being added: String and WVSSAddress. This was causing an exception
when the `.url` property was being accessed on Strings.

I have no idea if I'm ObjC-ing correctly with these collections. 